### PR TITLE
Make gplas-formatted output optional

### DIFF
--- a/ensemble_classifier.sh
+++ b/ensemble_classifier.sh
@@ -11,18 +11,19 @@ source $CONDA_PATH/etc/profile.d/conda.sh
 cd scripts
 
 #process flags provided
-while getopts :i:t:o:f flag; do
+while getopts :i:t:o:fg flag; do
 	case $flag in
 		i) path=$OPTARG;;
 		t) tools=$OPTARG;;
                 o) output_directory=$OPTARG;;
-		f) force='true'
+		f) force='true';;
+		g) gplas_output='true'
 	esac
 done
 
 #if input or output flags are not present or input is incorrect, write message and quit
-[ -z $path ] && echo "Please provide the path to your input folder with -i" && exit 1 
-[ -z $output_directory ] && echo "Please provide the name of the output directory" && exit 1
+[ -z $path ] && echo "Please provide the path to your input folder (-i)" && exit 1 
+[ -z $output_directory ] && echo "Please provide the name of the output directory (-o)" && exit 1
 [ ! -d ../$path ] && echo "The input folder does not exist." && exit 1
 
 #create output directory
@@ -88,7 +89,11 @@ fi
 #gather and combine results
 conda activate r_codes_ec_lv
 bash gather_results.sh -t $tools -o $output_directory
-#create a directory for the gplas output format
-mkdir ../$output_directory/results_gplas_format
-Rscript combine_results.R ../$path $output_directory
+Rscript combine_results.R $output_directory
 
+#put results in gplas format
+if [[ $gplas_output = 'true' ]]; then
+	#create a directory for the gplas output format
+	mkdir ../$output_directory/results_gplas_format
+	Rscript get_gplas_output.R ../$path $output_directory
+fi

--- a/ensemble_classifier.sh
+++ b/ensemble_classifier.sh
@@ -39,21 +39,16 @@ else
 	mkdir ../$output_directory
 fi
 
+#start plasmidEC
+echo "Starting plasmidEC, using the software combination $tools."
+
 #save list of conda envs already existing
 envs=$(conda env list | awk '{print $1}' )
-
-#create an environment for running r codes
-if ! [[ $envs = *"r_codes_ec_lv"* ]]; then
-	conda create --name r_codes_ec_lv r=4.1
-	conda activate r_codes_ec_lv
-	conda install -c bioconda bioconductor-biostrings=2.60.0
-	conda install -c conda-forge r-plyr=1.8.6
-	conda install -c conda-forge r-dplyr=1.0.7
-fi
 
 #run specified tools, create conda env if not yet existing
 if [[ $tools = *"mlplasmids"* ]]; then
 	if ! [[ $envs = *"mlplasmids_ec_lv"* ]]; then
+		echo "Creating conda environment mlplasmids_ec_lv..."
 		conda env create --file=../yml/mlplasmids_ec_lv.yml
 	fi
 	conda activate mlplasmids_ec_lv
@@ -62,6 +57,7 @@ fi
 
 if [[ $tools = *"plascope"* ]]; then
 	if ! [[ $envs = *"plascope_ec_lv"* ]]; then
+		echo "Creating conda environment plascope_ec_lv..."
 		conda create --name plascope_ec_lv -c bioconda/label/cf201901 plascope
 	fi
 	conda activate plascope_ec_lv
@@ -70,6 +66,7 @@ fi
 
 if [[ $tools = *"platon"* ]]; then
 	if ! [[ $envs = *"platon_ec_lv"* ]]; then
+		echo "Creating conda environment platon_ec_lv..."
 		conda create --name platon_ec_lv -c bioconda platon=1.6
 	fi
 	conda activate platon_ec_lv
@@ -78,6 +75,7 @@ fi
 
 if [[ $tools = *"rfplasmid"* ]]; then
 	if ! [[ $envs = *"rfplasmid_ec_lv"* ]]; then
+		echo "Creating conda environment rfplasmid_ec_lv..."
 		conda create --name rfplasmid_ec_lv -c bioconda rfplasmid
 		conda activate rfplasmid_ec_lv
 		rfplasmid --initialize
@@ -93,6 +91,16 @@ Rscript combine_results.R $output_directory
 
 #put results in gplas format
 if [[ $gplas_output = 'true' ]]; then
+	#create an environment for running r codes
+	if ! [[ $envs = *"r_codes_ec_lv"* ]]; then
+		echo "Creating conda environment r_codes_ec_lv..."
+		conda create --name r_codes_ec_lv r=4.1
+		conda activate r_codes_ec_lv
+		conda install -c bioconda bioconductor-biostrings=2.60.0
+		conda install -c conda-forge r-plyr=1.8.6
+		conda install -c conda-forge r-dplyr=1.0.7
+	fi
+
 	#create a directory for the gplas output format
 	mkdir ../$output_directory/results_gplas_format
 	Rscript get_gplas_output.R ../$path $output_directory

--- a/scripts/combine_results.R
+++ b/scripts/combine_results.R
@@ -1,27 +1,7 @@
-library(plyr)
-library(Biostrings)
-library(dplyr)
 
-##get the directory which contains the fasta files from the arguments on the command line.
+##get the input and output dir from command line arguments.
 arguments = commandArgs(trailingOnly=TRUE)
-input_directory=arguments[1]
-output_directory=arguments[2]
-
-#list all the fasta files in the input directory
-all_files=list.files(path=input_directory)
-
-#create an empty dataframe for containing the results
-contig_lengths<-data.frame(Contig_name=character(0),Contig_length=integer(0))
-
-#loop thru all files and extract the name of the contig and the length
-for (genomes in all_files) {
-  file_path<-paste(input_directory,'/',genomes,sep='')
-  fasta_parsed<-readDNAStringSet(filepath = file_path,format='fasta' )
-  Contig_name<-as.character(names(fasta_parsed))
-  Contig_length<-as.integer(lengths(fasta_parsed))
-  tmp_df<-data.frame(Contig_name,Contig_length)
-  contig_lengths<-rbind(contig_lengths,tmp_df)
-}
+output_directory=arguments[1]
 
 ##Load results
 all_results_path<-paste("../",output_directory,"/all_predictions.csv",sep='')
@@ -50,7 +30,7 @@ combined <- merge(merge(mlplasmids,platon,all = TRUE),merge(rfplasmid,plascope, 
 combined <- combined[, colSums(is.na(combined)) != nrow(combined)] #remove column of non-included tool
 #replace NA of mlplasmids with 'chromosome'.if the column exists
 if("mlplasmids" %in% colnames(combined)) {
-  combined$mlplasmids<-ifelse(is.na(combined$mlplasmids),'chromosome',as.character(combined$mlplasmids));
+ combined$mlplasmids<-ifelse(is.na(combined$mlplasmids),'chromosome',as.character(combined$mlplasmids));
 }
 
 ##Assign plasmid if called by more than one of the tools
@@ -62,36 +42,4 @@ combined$classification[combined$plasmid_count>1] <- "plasmid"
 combined_path<-paste('../',output_directory,'/plasmidEC_output.csv',sep='')
 write.csv(combined,combined_path,row.names = FALSE)
 
-##write gplas output
-gplas_output<-combined
-#get the prob of being a chromosome - for cases of plascope unclassified, this will provide a probability of 0.5 if split decision.
-gplas_output$Prob_Chromosome<-ifelse(gplas_output$plascope=='unclassified', round((2-as.numeric(gplas_output$plasmid_count))/2,2), round((3-as.numeric(gplas_output$plasmid_count))/3,2))
-#get the probability of being a plasmid
-gplas_output$Prob_Plasmid<-ifelse(gplas_output$plascope=='unclassified', round((as.numeric(gplas_output$plasmid_count))/2,2), round((as.numeric(gplas_output$plasmid_count))/3,2))
-#cases in which prob=0.5 are named as plasmid.
-gplas_output$classification<-ifelse(gplas_output$Prob_Plasmid==0.5,'Plasmid',as.character(gplas_output$classification))
-##replace with capital letter the predictions
-gplas_output$classification<-gsub(gplas_output$classification, pattern="plasmid", replacement="Plasmid")
-gplas_output$classification<-gsub(gplas_output$classification, pattern="chromosome", replacement="Chromosome")
-#combine with contig-lengths
-gplas_output<-join(gplas_output,contig_lengths)
-
-#create output
-#1. get the names of the strains in a list
-strain_names_list <- vector(mode = "list")
-for (row in 1:nrow(gplas_output)){
-  strain_names_list<-append(strain_names_list,as.character(gplas_output[row,2]))
-
-}
-strain_names_list<-unique(strain_names_list)
-
-# create data_frames
-for (genome in strain_names_list) {
-  individual_gplas<-filter(gplas_output,gplas_output$genome_id==genome)
-  individual_gplas_ordered<-individual_gplas[,c(8,9,7,1)]
-  names(individual_gplas_ordered)<-c('Prob_Chromosome','Prob_Plasmid','Prediction','Contig_name')
-  individual_gplas_ordered<-join(individual_gplas_ordered,contig_lengths)
-  output_path<-paste('../',output_directory,'/results_gplas_format/',genome,'_plasmid_prediction.tab',sep='')
-  write.table(individual_gplas_ordered,output_path,row.names = FALSE, sep='\t')
-}
 

--- a/scripts/get_gplas_output.R
+++ b/scripts/get_gplas_output.R
@@ -1,0 +1,62 @@
+library(plyr)
+library(Biostrings)
+library(dplyr)
+
+##get the directory which contains the fasta files from the arguments on the command line.
+arguments = commandArgs(trailingOnly=TRUE)
+input_directory=arguments[1]
+output_directory=arguments[2]
+
+#load results file
+combined_path<-paste('../',output_directory,'/plasmidEC_output.csv',sep='')
+combined <- read.csv(combined_path)
+
+##write gplas output
+gplas_output<-combined
+#get the prob of being a chromosome - for cases of plascope unclassified, this will provide a probability of 0.5 if split decision.
+gplas_output$Prob_Chromosome<-ifelse(gplas_output$plascope=='unclassified', round((2-as.numeric(gplas_output$plasmid_count))/2,2), round((3-as.numeric(gplas_output$plasmid_count))/3,2))
+#get the probability of being a plasmid
+gplas_output$Prob_Plasmid<-ifelse(gplas_output$plascope=='unclassified', round((as.numeric(gplas_output$plasmid_count))/2,2), round((as.numeric(gplas_output$plasmid_count))/3,2))
+#cases in which prob=0.5 are named as plasmid.
+gplas_output$classification<-ifelse(gplas_output$Prob_Plasmid==0.5,'Plasmid',as.character(gplas_output$classification))
+##replace with capital letter the predictions
+gplas_output$classification<-gsub(gplas_output$classification, pattern="plasmid", replacement="Plasmid")
+gplas_output$classification<-gsub(gplas_output$classification, pattern="chromosome", replacement="Chromosome")
+
+##list all the fasta files in the input directory
+all_files=list.files(path=input_directory)
+
+#create an empty dataframe for containing the results
+contig_lengths<-data.frame(Contig_name=character(0),Contig_length=integer(0))
+
+#loop thru all files and extract the name of the contig and the length
+for (genomes in all_files) {
+  file_path<-paste(input_directory,'/',genomes,sep='')
+  fasta_parsed<-readDNAStringSet(filepath = file_path,format='fasta' )
+  Contig_name<-as.character(names(fasta_parsed))
+  Contig_length<-as.integer(lengths(fasta_parsed))
+  tmp_df<-data.frame(Contig_name,Contig_length)
+  contig_lengths<-rbind(contig_lengths,tmp_df)
+}
+
+#combine with contig-lengths
+gplas_output<-join(gplas_output,contig_lengths)
+
+#create output
+#1. get the names of the strains in a list
+strain_names_list <- vector(mode = "list")
+for (row in 1:nrow(gplas_output)){
+  strain_names_list<-append(strain_names_list,as.character(gplas_output[row,2]))
+
+}
+strain_names_list<-unique(strain_names_list)
+
+# create data_frames
+for (genome in strain_names_list) {
+  individual_gplas<-filter(gplas_output,gplas_output$genome_id==genome)
+  individual_gplas_ordered<-individual_gplas[,c(8,9,7,1)]
+  names(individual_gplas_ordered)<-c('Prob_Chromosome','Prob_Plasmid','Prediction','Contig_name')
+  individual_gplas_ordered<-join(individual_gplas_ordered,contig_lengths)
+  output_path<-paste('../',output_directory,'/results_gplas_format/',genome,'_plasmid_prediction.tab',sep='')
+  write.table(individual_gplas_ordered,output_path,row.names = FALSE, sep='\t')
+}


### PR DESCRIPTION
Moved code formatting output for gplas to a separate script.
This script is only called when option -g is specified (option still needs to be added to README).